### PR TITLE
Fix Map serialization in toolResult

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -42,8 +42,11 @@ export function toolResult(data: unknown): {
             ? data
             : JSON.stringify(
                 data,
-                (_key, value) =>
-                  typeof value === "bigint" ? value.toString() : value,
+                (_key, value) => {
+                  if (value instanceof Map) return Object.fromEntries(value);
+                  if (typeof value === "bigint") return value.toString();
+                  return value;
+                },
                 2,
               ),
       },


### PR DESCRIPTION
## Summary

- `getAllOrderDetails()` returns `valid` and `invalid` as JS `Map` objects (from Rust `BTreeMap` via Tsify/WASM)
- `getDeploymentTransactionArgs()` returns `approvals` as a `Map`
- `JSON.stringify(new Map([...]))` produces `"{}"`, silently dropping all entries
- This causes `raindex_list_strategies` to always return `{ "valid": {}, "invalid": {} }` and `raindex_deploy_strategy` to lose approval data

## Fix

Add a `Map`-aware replacer to `JSON.stringify` in `toolResult()` that converts `Map` instances to plain objects via `Object.fromEntries()` before serialization.

## Test plan

- [ ] Call `raindex_list_strategies` — should return populated `valid`/`invalid` maps
- [ ] Call `raindex_deploy_strategy` — should return `approvals` with entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)